### PR TITLE
HOTFIX: Series don't concatenate the same way as they append

### DIFF
--- a/notebooks/Week3/Topic_Modeling_Project.ipynb
+++ b/notebooks/Week3/Topic_Modeling_Project.ipynb
@@ -915,7 +915,7 @@
     "                # get value of topic_names dict based on key\n",
     "                topic_name = topic_names[topic_num]\n",
     "                topic_keywords = \", \".join([word for word, prop in wp])\n",
-    "                topics_df = topics_df.append(pd.Series([int(topic_num), topic_name, round(prop_topic,4), topic_keywords]), ignore_index=True)\n",
+    "                topics_df = pd.concat([topics_df, pd.Series([int(topic_num), topic_name, round(prop_topic,4), topic_keywords]).to_frame().T], ignore_index=True)\n",
     "            else:\n",
     "                break\n",
     "    topics_df.columns = ['Dominant_Topic', 'Dominant_Topic_Name', 'Perc_Contribution', 'Topic_Keywords']\n",


### PR DESCRIPTION
Apologies for the last commit -- Series must be turned into dataframes to concatenate in the way append was functioning prior

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.to_frame.html